### PR TITLE
Fix error while removing items with react-masonry-mixin 

### DIFF
--- a/item.js
+++ b/item.js
@@ -428,7 +428,11 @@ Item.prototype.removeTransitionStyles = function() {
 
 // remove element from DOM
 Item.prototype.removeElem = function() {
-  this.element.parentNode.removeChild( this.element );
+  // sometimes, with React, the parentNode is not accessible
+  if (this.element.parentNode) {
+    this.element.parentNode.removeChild( this.element );
+  }
+
   this.emitEvent( 'remove', [ this ] );
 };
 


### PR DESCRIPTION
Not sure if doing something wrong, but when updating items with ´react-masonry-mixin´, if any item was removed, it would throw an error concerning a null parentNode in `Item.prototype.removeElem`.
By adding a condition before removing the item element from the parentNode, managed to override this issue in `react-masonry-mixin`.
